### PR TITLE
Update dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "."
     schedule:
-      interval: "daily"
+      interval: "monthly"
     versioning-strategy: increase
     groups:
       npm:
@@ -12,7 +12,7 @@ updates:
   - package-ecosystem: "github-actions"
     directory: ".github/workflows"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     groups:
       gha:
         patterns:


### PR DESCRIPTION
This repo does not need updates this often. It only needs the updates prior to an npm release realistically. The daily PRs are just annoying.